### PR TITLE
FIX-002: Module ConfigParser has changed name

### DIFF
--- a/accessninja/config.py
+++ b/accessninja/config.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-import ConfigParser
+import configparser
 import os
 
 
 class Config(object):
     def __init__(self):
 
-        config = ConfigParser.ConfigParser()
+        config = configparser.ConfigParser()
         config.read(os.path.expanduser('~/.accessninja/config'))
 
         if not config.has_section('general'):


### PR DESCRIPTION
* Due to PEP8 compliance
* See: https://docs.python.org/3/library/configparser.html