### PR TITLE
FIX-014: The configuration file is twice the size

### DIFF
--- a/accessninja/deployers/junos.py
+++ b/accessninja/deployers/junos.py
@@ -38,7 +38,6 @@ class JunosDeployer(object):
         f = NamedTemporaryFile(delete=False)
         print('[{}] Stored temporary config at {}'.format(self._device.name, f.name))
         f.write(bytes(self._device.rendered_config, encoding='utf-8'))
-        f.write(bytes(self._device.rendered_config, encoding='utf-8'))
         f.flush()
 
         tr = paramiko.Transport((self._device.name, 22))


### PR DESCRIPTION
* This caused twice the processing time to load on the CFWs
* This resulted in an alert of the CPU usage of the Routing Engine